### PR TITLE
create `File` struct for easy image displaying

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Noskcaj <kcajdev@gmail.com>"]
 name = "iterm2"
-version = "0.2.1"
+version = "0.3.0"
 description = "A library for using iTerm2 escape codes"
 repository = "https://github.com/Noskcaj19/iterm2"
 homepage = "https://github.com/Noskcaj19/iterm2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/Noskcaj19/iterm2"
 homepage = "https://github.com/Noskcaj19/iterm2"
 readme = "README.md"
 license = "MIT"
+edition = "2018"
 
 keywords = [
     "terminal",

--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@ A Rust crate to allow easy access to the various escape codes in iTerm2.
 # Usage
 
 ```rust
-extern crate iterm2;
-use iterm2::*;
+use iterm2::{AttentionType, Dimension, File};
 
-clear_scrollback().unwrap();
-anchor("https://google.com", "google").unwrap();
-attention(AttentionType::Firework).unwrap();
+iterm2::clear_scrollback()?;
+iterm2::anchor("https://google.com", "google")?;
+iterm2::attention(AttentionType::Firework)?;
+
+File::read("path/to/some/image.png")?
+    .height(Dimension::Cells(14))
+    .width(Dimension::Percent(100))
+    .preserve_aspect_ratio(false)
+    .show()?;
 ```

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,0 +1,12 @@
+use iterm2::{Dimension, File};
+use std::io;
+
+fn main() -> io::Result<()> {
+    File::read("path/to/divider.png")?
+        .width(Dimension::Percent(100))
+        .height(Dimension::Pixel(1))
+        .preserve_aspect_ratio(false)
+        .show()?;
+
+    Ok(())
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,134 @@
+use std::{
+    borrow::Cow,
+    fs,
+    io::{self, stdout, Write},
+    path::Path,
+};
+
+/// Used for specifying how large an image should be rendered
+#[derive(Debug, Copy, Clone)]
+pub enum Dimension {
+    /// iterm will choose a size for you
+    Auto,
+    /// the amount of pixels that will be used
+    Pixel(u32),
+    /// the amount of cells that will be used
+    Cells(u32),
+    /// percent of the current terminal size
+    Percent(u8),
+}
+impl std::fmt::Display for Dimension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Dimension::Auto => write!(f, "auto"),
+            Dimension::Pixel(val) => write!(f, "{}px", val),
+            Dimension::Cells(val) => write!(f, "{}", val),
+            Dimension::Percent(val) => {
+                assert!(*val <= 100, "percent cannot be greater than 100");
+                write!(f, "{}%", val)
+            }
+        }
+    }
+}
+
+/// A builder for drawing images in the terminal
+/// ```rust,no_run
+/// use iterm2::{Dimension, File};
+///
+/// File::read("path/to/some/image.png")?
+///     .height(Dimension::Cells(14))
+///     .width(Dimension::Percent(100))
+///     .preserve_aspect_ratio(false)
+///     .show()?;
+/// # Ok::<_, std::io::Error>(())
+/// ```
+#[derive(Default)]
+pub struct File<'c> {
+    name: Option<String>,
+    size: Option<u32>,
+    width: Option<Dimension>,
+    height: Option<Dimension>,
+    preserve_aspect_ratio: Option<bool>,
+    contents: Cow<'c, [u8]>,
+}
+impl<'c> File<'c> {
+    /// creates a new image from its content
+    pub fn new(contents: &'c [u8]) -> Self {
+        Self {
+            contents: contents.into(),
+            ..Default::default()
+        }
+    }
+
+    /// creates a new image from the given file
+    pub fn read(path: impl AsRef<Path>) -> io::Result<Self> {
+        let contents = fs::read(path)?;
+        Ok(Self {
+            contents: contents.into(),
+            ..Default::default()
+        })
+    }
+
+    /// Set the name of the file, only used with [`download`](struct.File.html#method.download).
+    ///
+    /// Default is "Unnamed file".
+    pub fn name(&mut self, name: String) -> &mut Self {
+        self.name = Some(name);
+        self
+    }
+    /// Set the size of the file in bytes.
+    /// It will be used with [`download`](struct.File.html#method.download) for showing the progress indicator.
+    pub fn size(&mut self, size: u32) -> &mut Self {
+        self.size = Some(size);
+        self
+    }
+    /// Set the width of the image
+    pub fn width(&mut self, width: Dimension) -> &mut Self {
+        self.width = Some(width);
+        self
+    }
+    /// Set the height of the image
+    pub fn height(&mut self, height: Dimension) -> &mut Self {
+        self.height = Some(height);
+        self
+    }
+    /// Specifies, whether the aspect ratio of the image should be kept
+    pub fn preserve_aspect_ratio(&mut self, preserve: bool) -> &mut Self {
+        self.preserve_aspect_ratio = Some(preserve);
+        self
+    }
+
+    fn action(&self, inline: bool, img_data: &[u8]) -> io::Result<()> {
+        write!(stdout(), "\x1b]1337;File=")?;
+        if let Some(name) = &self.name {
+            write!(stdout(), "name={};", name)?;
+        }
+        if let Some(size) = &self.size {
+            write!(stdout(), "size={};", size)?;
+        }
+        if let Some(width) = &self.width {
+            write!(stdout(), "width={};", width)?;
+        }
+        if let Some(height) = &self.height {
+            write!(stdout(), "height={};", height)?;
+        }
+        if let Some(ar) = self.preserve_aspect_ratio {
+            write!(stdout(), "preserveAspectRatio={};", ar as u8)?;
+        }
+        write!(stdout(), "inline={};", inline as u8)?;
+
+        write!(stdout(), ":{}\x07", base64::encode(img_data))?;
+        Ok(())
+    }
+
+    /// Download the file
+    pub fn download(&self) -> io::Result<()> {
+        self.action(false, &self.contents)
+    }
+
+    /// Display the image in the terminal.
+    pub fn show(&self) -> io::Result<()> {
+        self.action(true, &self.contents)?;
+        writeln!(stdout())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,24 @@
 //!
 //! # Usage
 //!
-//! ```rust
-//! use iterm2::*;
+//! ```rust,no_run
+//! use iterm2::{AttentionType, Dimension, File};
 //!
-//! clear_scrollback().unwrap();
-//! anchor("https://google.com", "google").unwrap();
-//! attention(AttentionType::Firework).unwrap();
+//! iterm2::clear_scrollback()?;
+//! iterm2::anchor("https://google.com", "google")?;
+//! iterm2::attention(AttentionType::Firework)?;
+//!
+//! File::read("path/to/some/image.png")?
+//!     .height(Dimension::Cells(14))
+//!     .width(Dimension::Percent(100))
+//!     .preserve_aspect_ratio(false)
+//!     .show()?;
+//!
+//! # Ok::<_, std::io::Error>(())
 //! ```
-//!
+
+mod file;
+pub use file::*;
 
 use base64::encode;
 use std::io::{self, stdout, Write};
@@ -222,22 +232,6 @@ pub fn get_cell_size(filename: &str) -> io::Result<(f32, f32)> {
 #[allow(unused_variables)]
 pub fn get_terminal_variable(filename: &str) -> io::Result<String> {
     unimplemented!()
-}
-
-/// Download a file. Accepts raw file contents and option arguments
-///
-/// See the [iTerm2 docs](https://www.iterm2.com/documentation-images.html) for more information
-pub fn download_file(args: &[(&str, &str)], img_data: &[u8]) -> io::Result<()> {
-    let joined_args = args
-        .iter()
-        .map(|item| format!("{}={}", item.0, item.1))
-        .collect::<Vec<_>>()
-        .join(";");
-    stdout().write_all(format!("\x1b]1337;File={}:", joined_args).as_bytes())?;
-
-    let encoded_data = base64::encode(img_data);
-    stdout().write_all(&encoded_data.as_bytes())?;
-    stdout().write_all(b"\x07")
 }
 
 /// Configures touchbar key lables

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,7 @@
 //!
 
 use base64::encode;
-use std::io::{stdout, Write};
-
-pub type TerminalError = Result<(), std::io::Error>;
+use std::io::{self, stdout, Write};
 
 /// The possible cusor shpaes
 #[derive(Debug, Clone, Copy)]
@@ -41,12 +39,12 @@ pub enum AttentionType {
 }
 
 /// Display a clickable link with custom display text
-pub fn anchor(url: &str, display_text: &str) -> TerminalError {
+pub fn anchor(url: &str, display_text: &str) -> io::Result<()> {
     stdout().write_all(format!("\x1b]8;;{}\x07{}\x1b]8;;\x07", url, display_text).as_bytes())
 }
 
 /// Set the shape of the cursor
-pub fn set_cursor_shape(shape: CursorShape) -> TerminalError {
+pub fn set_cursor_shape(shape: CursorShape) -> io::Result<()> {
     use crate::CursorShape::*;
     let shape_val = match shape {
         Block => 0,
@@ -57,47 +55,47 @@ pub fn set_cursor_shape(shape: CursorShape) -> TerminalError {
 }
 
 /// Set a mark at the current line
-pub fn set_mark() -> TerminalError {
+pub fn set_mark() -> io::Result<()> {
     stdout().write_all(b"\x1b]1337;SetMark\x07")
 }
 
 /// Attempt to make iTerm the focused application
-pub fn steal_focus() -> TerminalError {
+pub fn steal_focus() -> io::Result<()> {
     stdout().write_all(b"\x1b]1337;StealFocus\x07")
 }
 
 /// Clear the terminals scroll history
-pub fn clear_scrollback() -> TerminalError {
+pub fn clear_scrollback() -> io::Result<()> {
     stdout().write_all(b"\x1b]1337;ClearScrollback\x07")
 }
 
 /// Sets the terminals current working directory
-pub fn set_current_dir(dir: &str) -> TerminalError {
+pub fn set_current_dir(dir: &str) -> io::Result<()> {
     stdout().write_all(format!("\x1b]1337;CurrentDir={}\x07", dir).as_bytes())
 }
 
 /// Send a system wide Growl notification
-pub fn send_notification(message: &str) -> TerminalError {
+pub fn send_notification(message: &str) -> io::Result<()> {
     stdout().write_all(format!("\x1b]9;{}\x07", message).as_bytes())
 }
 
 /// Sets the clipboard
 // TODO: Add support for the other clipboards
-pub fn set_clipboard(text: &str) -> TerminalError {
+pub fn set_clipboard(text: &str) -> io::Result<()> {
     stdout().write_all(b"\x1b]1337;CopyToClipboard=\x07")?;
     stdout().write_all(text.as_bytes())?;
     stdout().write_all(b"\n\x1b]1337;EndCopy\x07")
 }
 
 /// Sets the tab colors to a custom rgb value
-pub fn set_tab_colors(red: u8, green: u8, blue: u8) -> TerminalError {
+pub fn set_tab_colors(red: u8, green: u8, blue: u8) -> io::Result<()> {
     stdout().write_all(format!("\x1b]6;1;bg;red;brightness;{}\x07", red).as_bytes())?;
     stdout().write_all(format!("\x1b]6;1;bg;green;brightness;{}\x07", green).as_bytes())?;
     stdout().write_all(format!("\x1b]6;1;bg;blue;brightness;{}\x07", blue).as_bytes())
 }
 
 /// Restore the tab colors to defaults
-pub fn restore_tab_colors() -> TerminalError {
+pub fn restore_tab_colors() -> io::Result<()> {
     stdout().write_all(b"\x1b]6;1;bg;*;default\x07")
 }
 
@@ -105,7 +103,7 @@ pub fn restore_tab_colors() -> TerminalError {
 ///
 /// For details on the format, see "Change the color palette" at https://www.iterm2.com/documentation-escape-codes.html
 // TODO: Add better parameters
-pub fn set_color_palette(colors: &str) -> TerminalError {
+pub fn set_color_palette(colors: &str) -> io::Result<()> {
     stdout().write_all(format!("\x1b]1337;SetColors={}\x07", colors).as_bytes())
 }
 
@@ -150,7 +148,7 @@ impl Annotation {
     }
 
     /// Display the annotation
-    pub fn show(&self) -> TerminalError {
+    pub fn show(&self) -> io::Result<()> {
         let value = match self {
             Annotation {
                 message: msg,
@@ -185,13 +183,13 @@ impl Annotation {
 }
 
 /// Set the visibility of the cursor guide
-pub fn cursor_guide(show: bool) -> TerminalError {
+pub fn cursor_guide(show: bool) -> io::Result<()> {
     let value = if show { "yes" } else { "no" };
     stdout().write_all(format!("\x1b]1337;HighlightCursorLine={}\x07", value).as_bytes())
 }
 
 /// Trigger a dock bounce notification or fireworks
-pub fn attention(kind: AttentionType) -> TerminalError {
+pub fn attention(kind: AttentionType) -> io::Result<()> {
     use crate::AttentionType::*;
     let value = match kind {
         Yes => "yes",
@@ -202,7 +200,7 @@ pub fn attention(kind: AttentionType) -> TerminalError {
 }
 
 /// Set the terminal background to the image at a path
-pub fn set_background_image(filename: &str) -> TerminalError {
+pub fn set_background_image(filename: &str) -> io::Result<()> {
     let base64_filename = encode(filename.as_bytes());
     stdout()
         .write_all(format!("\x1b]1337;SetBackgroundImageFile={}\x07", base64_filename).as_bytes())
@@ -213,7 +211,7 @@ pub fn set_background_image(filename: &str) -> TerminalError {
 /// *Not yet implemented*
 //TODO: Implement
 #[allow(unused_variables)]
-pub fn get_cell_size(filename: &str) -> Result<(f32, f32), std::io::Error> {
+pub fn get_cell_size(filename: &str) -> io::Result<(f32, f32)> {
     unimplemented!()
 }
 
@@ -222,14 +220,14 @@ pub fn get_cell_size(filename: &str) -> Result<(f32, f32), std::io::Error> {
 /// *Not yet implemented*
 //TODO: Implement
 #[allow(unused_variables)]
-pub fn get_terminal_variable(filename: &str) -> Result<String, std::io::Error> {
+pub fn get_terminal_variable(filename: &str) -> io::Result<String> {
     unimplemented!()
 }
 
 /// Download a file. Accepts raw file contents and option arguments
 ///
 /// See the [iTerm2 docs](https://www.iterm2.com/documentation-images.html) for more information
-pub fn download_file(args: &[(&str, &str)], img_data: &[u8]) -> TerminalError {
+pub fn download_file(args: &[(&str, &str)], img_data: &[u8]) -> io::Result<()> {
     let joined_args = args
         .iter()
         .map(|item| format!("{}={}", item.0, item.1))
@@ -245,31 +243,31 @@ pub fn download_file(args: &[(&str, &str)], img_data: &[u8]) -> TerminalError {
 /// Configures touchbar key lables
 ///
 /// Seethe [iTerm2 docs](https://www.iterm2.com/documentation-escape-codes.html) for more information
-pub fn set_touchbar_key_label(key: &str, value: &str) -> TerminalError {
+pub fn set_touchbar_key_label(key: &str, value: &str) -> io::Result<()> {
     stdout().write_all(format!("\x1b]1337;SetKeyLabel={}={}\x07", key, value).as_bytes())
 }
 
 /// Push the current key labels
-pub fn push_current_touchbar_labels() -> TerminalError {
+pub fn push_current_touchbar_labels() -> io::Result<()> {
     stdout().write_all(b"\x1b]1337;PushKeyLabels\x07")
 }
 
 /// Pop the current key labels
-pub fn pop_current_touchbar_labels() -> TerminalError {
+pub fn pop_current_touchbar_labels() -> io::Result<()> {
     stdout().write_all(b"\x1b]1337;PopKeyLabels\x07")
 }
 
 /// Push a specific touchbar key label by name
-pub fn push_touchbar_label(label: &str) -> TerminalError {
+pub fn push_touchbar_label(label: &str) -> io::Result<()> {
     stdout().write_all(format!("\x1b1337;PushKeyLabels={}\x07", label).as_bytes())
 }
 
 /// Pop a specific touchbar key label by name
-pub fn pop_touchbar_label(label: &str) -> TerminalError {
+pub fn pop_touchbar_label(label: &str) -> io::Result<()> {
     stdout().write_all(format!("\x1b1337;PopKeyLabels={}\x07", label).as_bytes())
 }
 
 /// Sets the terminals unicode version
-pub fn set_unicode_version(version: u8) -> TerminalError {
+pub fn set_unicode_version(version: u8) -> io::Result<()> {
     stdout().write_all(format!("\x1b1337;UnicodeVersion={}\x07", version).as_bytes())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //! # Usage
 //!
 //! ```rust
-//! extern crate iterm2;
 //! use iterm2::*;
 //!
 //! clear_scrollback().unwrap();
@@ -14,11 +13,8 @@
 //! ```
 //!
 
-extern crate base64;
-
 use base64::encode;
-use std::io::stdout;
-use std::io::Write;
+use std::io::{stdout, Write};
 
 pub type TerminalError = Result<(), std::io::Error>;
 
@@ -51,7 +47,7 @@ pub fn anchor(url: &str, display_text: &str) -> TerminalError {
 
 /// Set the shape of the cursor
 pub fn set_cursor_shape(shape: CursorShape) -> TerminalError {
-    use CursorShape::*;
+    use crate::CursorShape::*;
     let shape_val = match shape {
         Block => 0,
         VerticalBar => 1,
@@ -196,7 +192,7 @@ pub fn cursor_guide(show: bool) -> TerminalError {
 
 /// Trigger a dock bounce notification or fireworks
 pub fn attention(kind: AttentionType) -> TerminalError {
-    use AttentionType::*;
+    use crate::AttentionType::*;
     let value = match kind {
         Yes => "yes",
         No => "no",


### PR DESCRIPTION
the struct is used like this:
```rust
File::read("path/to/some/image.png")?
    .height(Dimension::Cells(14))
    .width(Dimension::Percent(100))
    .preserve_aspect_ratio(false)
    .show()?
```
or like this:
```rust
let file_contents: &[u8] = ...;
File::new(contents)
    /* .option(val) */
    .download()?;
```

Also, I removed your `TerminalError` type alias, since I felt like it didn't add any value over `io::Result<()>` and the name was confusing.
If you don't want that change I can revert that of course.

This is a breaking change since I removed the now obsolete `download_file` function.